### PR TITLE
Implement AioFiles to remove blocking IO from executing thread

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='GPLv3',
     description='asyncio compatibility shim for tinydb',
     packages=['aiotinydb'],
-    install_requires=['aiofilelock', 'tinydb'],
+    install_requires=['aiofilelock', 'tinydb', 'aiofiles'],
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This merge implements the[AioFiles](https://github.com/Tinche/aiofiles) library to do the actual IO and passed the read data to a StringIO instance. This is done, because the current `open` implementation would still block the event loop. 