### PR TITLE
use provided name in table()

### DIFF
--- a/aiotinydb/database.py
+++ b/aiotinydb/database.py
@@ -60,10 +60,12 @@ class AIOTinyDB(TinyDB):
             raise DatabaseNotReady('File is not opened. Use with AIOTinyDB(...):')
         return super().purge_tables()
 
-    def table(self, name='_default', **options):
+    def table(self, name=None, **options):
+        if name is None:
+            name = self.DEFAULT_TABLE
         if self._storage is None:
             raise DatabaseNotReady('File is not opened. Use with AIOTinyDB(...):')
-        return super().table(name='_default', **options)
+        return super().table(name, **options)
 
     def tables(self):
         if self._storage is None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -81,3 +81,14 @@ class TestDatabase(BaseCase):
                 async with db:
                     pass
         self.loop.run_until_complete(coro())
+
+    def test_alternate_tables(self):
+        async def coro():
+            async with AIOTinyDB(self.file.name) as db:
+                db.insert(dict(index='default'))
+                db.table('alt').insert(dict(index='alt'))
+                self.assertEqual(len(db.tables()), 2)
+                self.assertEqual(len(db), 1)
+                self.assertEqual(len(db.table()), 1)
+                self.assertEqual(len(db.table('alt')), 1)
+        self.loop.run_until_complete(coro())


### PR DESCRIPTION
## Defect

The `table()` function in `aiotinydb.database.AIOTinyDB` accepts a `name` argument.
This argument subsquently is discarded, and `TinyDB.table()` is always called with the hardcoded string `"_default"`. 

## Changes:

* The `name` argument in `AIOTinyDB.table()` defaults to `self.DEFAULT_TABLE`, and not the hardcoded string "_default"
* `name` is forwarded to `TinyDB.table()`

## Related issues:

TinyDB 3.9.0.post1 introduced using `os.fsync(self._handle.fileno())` in `storages.py` to flush file descriptors to disk. This causes an `UnsupportedOperation: fileno` error on my machine. I'm not sure yet what conditions trigger this, and am working on a bug report.

Edit: the fileno error apparently also reproduces in Travis.