### PR TITLE
Prepare Release v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ loop.run_until_complete(test())
 loop.close()
 ```
 
-CPU-bound operations like `db.search()`, `db.update()` etc. are executed synchronously and may block the event loop under heavy load. Use multiprocessing if that's an issue (see [examples/processpool.py](examples/processpool.py) for an example).
+CPU-bound operations like `db.search()`, `db.update()` etc. are executed synchronously and may block the event loop under heavy load. Use multiprocessing if that's an issue (see [#6](https://github.com/aiotinydb/aiotinydb/issues/6#issuecomment-1125343152) and [examples/processpool.py](examples/processpool.py) for an example).
 
 ## Middleware
 

--- a/aiotinydb/__init__.py
+++ b/aiotinydb/__init__.py
@@ -3,16 +3,16 @@
 
     Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from .database import AIOTinyDB

--- a/aiotinydb/__init__.py
+++ b/aiotinydb/__init__.py
@@ -14,6 +14,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+asyncio compatibility shim for TinyDB
+
+Enables usage of TinyDB in asyncio-aware contexts without slow synchronous IO.
+"""
+
 from .database import AIOTinyDB
 from .exceptions import DatabaseNotReady
 from .storage import AIOJSONStorage, AIOImmutableJSONStorage

--- a/aiotinydb/__init__.py
+++ b/aiotinydb/__init__.py
@@ -1,20 +1,19 @@
-"""
-    aiotinydb - asyncio compatibility shim for tinydb
+# aiotinydb - asyncio compatibility shim for tinydb
 
-    Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+# Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from .database import AIOTinyDB
 from .exceptions import DatabaseNotReady
 from .storage import AIOJSONStorage, AIOImmutableJSONStorage

--- a/aiotinydb/database.py
+++ b/aiotinydb/database.py
@@ -3,16 +3,16 @@
 
     Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 

--- a/aiotinydb/database.py
+++ b/aiotinydb/database.py
@@ -1,20 +1,18 @@
-"""
-    aiotinydb - asyncio compatibility shim for tinydb
+# aiotinydb - asyncio compatibility shim for tinydb
 
-    Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+# Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # pylint: disable=super-init-not-called,arguments-differ
 # pylint: disable=too-many-instance-attributes

--- a/aiotinydb/database.py
+++ b/aiotinydb/database.py
@@ -14,6 +14,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+This module contains the async-enabled `AIOTinyDB` database.
+"""
+
 # pylint: disable=super-init-not-called,arguments-differ
 # pylint: disable=too-many-instance-attributes
 from asyncio import Lock

--- a/aiotinydb/exceptions.py
+++ b/aiotinydb/exceptions.py
@@ -3,16 +3,16 @@
 
     Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 

--- a/aiotinydb/exceptions.py
+++ b/aiotinydb/exceptions.py
@@ -1,21 +1,18 @@
-"""
-    aiotinydb - asyncio compatibility shim for tinydb
+# aiotinydb - asyncio compatibility shim for tinydb
 
-    Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+# Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
-
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class AIOTinyDBError(Exception):
     """Base class for AIOTinyDB exceptions"""

--- a/aiotinydb/exceptions.py
+++ b/aiotinydb/exceptions.py
@@ -14,6 +14,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+Contains the error types for aiotinydb.
+"""
+
+
 class AIOTinyDBError(Exception):
     """Base class for AIOTinyDB exceptions"""
 

--- a/aiotinydb/middleware.py
+++ b/aiotinydb/middleware.py
@@ -3,16 +3,16 @@
 
     Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 # pylint: disable=too-few-public-methods

--- a/aiotinydb/middleware.py
+++ b/aiotinydb/middleware.py
@@ -14,6 +14,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+Contains the base classes `AIOMiddleware` and `AIOMiddlewareMixin` for
+async middlewares and implementations.
+"""
+
 # pylint: disable=too-few-public-methods
 from types import TracebackType
 from typing import NoReturn, Optional, Type, TypeVar

--- a/aiotinydb/middleware.py
+++ b/aiotinydb/middleware.py
@@ -1,20 +1,19 @@
-"""
-    aiotinydb - asyncio compatibility shim for tinydb
+# aiotinydb - asyncio compatibility shim for tinydb
 
-    Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+# Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # pylint: disable=too-few-public-methods
 from types import TracebackType
 from typing import NoReturn, Optional, Type, TypeVar

--- a/aiotinydb/storage.py
+++ b/aiotinydb/storage.py
@@ -1,20 +1,19 @@
-"""
-    aiotinydb - asyncio compatibility shim for tinydb
+# aiotinydb - asyncio compatibility shim for tinydb
 
-    Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+# Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # pylint: disable=super-init-not-called
 import os
 import io

--- a/aiotinydb/storage.py
+++ b/aiotinydb/storage.py
@@ -3,16 +3,16 @@
 
     Copyright 2017 Pavel Pletenev <cpp.create@gmail.com>
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 # pylint: disable=super-init-not-called

--- a/aiotinydb/storage.py
+++ b/aiotinydb/storage.py
@@ -14,6 +14,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+Contains the base class `AIOStorage` for async storages and
+implementations.
+"""
+
 # pylint: disable=super-init-not-called
 import os
 import io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,19 +7,19 @@ name = 'aiotinydb'
 version = '2.0.0'
 description = 'asyncio compatibility shim for tinydb'
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 license = { file = "LICENSE.md" }
 authors = [{ name = "Pavel Pletenev", email = "cpp.create@gmail.com" }]
 maintainers = [{ name = "d-k-bo", email = "d-k-bo@mailbox.org" }]
 classifiers = [
-    'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+    'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
     'Development Status :: 4 - Beta',
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Operating System :: OS Independent',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Changes:
- introduced `Lesser` into all copyright notices
- license notices are now comments instead of docstrings (that's how it's usually done, so they aren't loaded into memory at runtime)
- added short docstrings for modules (pylint is now happy again :D)
- Updated pyproject.toml
  - license classifier marks this project as LGPL-3.0-or-later 
  - drop Python 3.6 Support (like TinyDB did)
  - explicitly mention compatibility with Python 3.11
- mention #6 in the README

Closes #11, #13.

@ASMfreaK Are these changes okay for you?